### PR TITLE
Misc web method fixes

### DIFF
--- a/lib/passage_flutter_web.dart
+++ b/lib/passage_flutter_web.dart
@@ -3,6 +3,7 @@
 // package as the core of your plugin.
 // ignore: avoid_web_libraries_in_flutter
 
+import 'dart:convert';
 import 'dart:js' as js;
 import 'dart:js_util' as js_util;
 import 'package:flutter/foundation.dart' as flutter;
@@ -117,8 +118,22 @@ class PassageFlutterWeb extends PassageFlutterPlatform {
 
   @override
   Future<bool> isAuthTokenValid(String authToken) async {
-    // TODO: custom implementation, not available in PassageJS
-    throw UnimplementedError('isAuthTokenValid() has not been implemented.');
+    try {
+      final parts = authToken.split('.');
+      if (parts.length != 3) {
+        return false;
+      }
+      final payload = utf8.decode(base64Url.decode(parts[1]));
+      final Map<String, dynamic> data = jsonDecode(payload);
+      if (data.containsKey('exp')) {
+        final int expirationTime = data['exp'] * 1000;
+        final int currentTime = DateTime.now().millisecondsSinceEpoch;
+        return expirationTime > currentTime;
+      }
+      return false;
+    } catch (e) {
+      return false;
+    }
   }
 
   @override


### PR DESCRIPTION
This PR includes the following web implementation updates:
* Fix to get `refreshAuthToken` method working ([PSG-2542](https://passage-identity.atlassian.net/browse/PSG-2542))
* Fix to return `null` if `getCurrentUser` fails ([PSG-2618](https://passage-identity.atlassian.net/browse/PSG-2618))
* Added `isAuthTokenValid` method to web to match mobile implementations ([PSG-2541](https://passage-identity.atlassian.net/browse/PSG-2541))

[PSG-2542]: https://passage-identity.atlassian.net/browse/PSG-2542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PSG-2618]: https://passage-identity.atlassian.net/browse/PSG-2618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PSG-2541]: https://passage-identity.atlassian.net/browse/PSG-2541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ