### PR TITLE
Social Login

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,7 +48,7 @@ android {
     dependencies {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
-        implementation 'id.passage.android:passage:1.5.1'
+        implementation 'id.passage.android:passage:1.6.0'
         implementation 'com.google.code.gson:gson:2.9.0'
     }
 

--- a/android/src/main/kotlin/id/passage/passage_flutter/PassageFlutterError.kt
+++ b/android/src/main/kotlin/id/passage/passage_flutter/PassageFlutterError.kt
@@ -13,4 +13,5 @@ internal enum class PassageFlutterError {
     CHANGE_PHONE_ERROR,
     IDENTIFIER_EXISTS_ERROR,
     OTP_ACTIVATION_EXCEEDED_ATTEMPTS,
+    SOCIAL_AUTH_ERROR,
 }

--- a/android/src/main/kotlin/id/passage/passage_flutter/PassageFlutterPlugin.kt
+++ b/android/src/main/kotlin/id/passage/passage_flutter/PassageFlutterPlugin.kt
@@ -54,6 +54,8 @@ class PassageFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
           "newLoginMagicLink" -> passageFlutter?.newLoginMagicLink(call, result)
           "magicLinkActivate" -> passageFlutter?.magicLinkActivate(call, result)
           "getMagicLinkStatus" -> passageFlutter?.getMagicLinkStatus(call, result)
+          "authorizeWith" -> passageFlutter?.authorizeWith(call, result)
+          "finishSocialAuthentication" -> passageFlutter?.finishSocialAuthentication(call, result)
           "getAuthToken" -> passageFlutter?.getAuthToken(result)
           "isAuthTokenValid" -> passageFlutter?.isAuthTokenValid(call, result)
           "refreshAuthToken" -> passageFlutter?.refreshAuthToken(result)

--- a/ios/Classes/PassageFlutter.swift
+++ b/ios/Classes/PassageFlutter.swift
@@ -227,6 +227,46 @@ internal class PassageFlutter {
         }
     }
     
+    // MARK: - Social Methods
+    internal func authorizeWith(arguments: Any?, result: @escaping FlutterResult) {
+        guard let connection = (arguments as? [String: String])?["connection"] else {
+            let error = PassageFlutterError.INVALID_ARGUMENT.defaultFlutterError
+            result(error)
+            return
+        }
+        Task {
+            do {
+                guard let safeConnection = PassageSocialConnection(rawValue: connection) else {
+                    let error = FlutterError(
+                        code: PassageFlutterError.SOCIAL_AUTH_ERROR.rawValue,
+                        message: "Invalid connection.",
+                        details: nil
+                    )
+                    result(error)
+                    return
+                }
+                guard let window = await UIApplication.shared.delegate?.window ?? nil else {
+                    let error = FlutterError(
+                        code: PassageFlutterError.SOCIAL_AUTH_ERROR.rawValue,
+                        message: "Could not access app window.",
+                        details: nil
+                    )
+                    result(error)
+                    return
+                }
+                let authResult = try await passage.authorize(with: safeConnection, in: window)
+                result(convertToJsonString(codable: authResult))
+            } catch {
+                let error = FlutterError(
+                    code: PassageFlutterError.SOCIAL_AUTH_ERROR.rawValue,
+                    message: error.localizedDescription,
+                    details: nil
+                )
+                result(error)
+            }
+        }
+    }
+    
     // MARK: - Token Methods
         
     internal func getAuthToken(result: @escaping FlutterResult) {

--- a/ios/Classes/PassageFlutterError.swift
+++ b/ios/Classes/PassageFlutterError.swift
@@ -8,6 +8,7 @@ internal enum PassageFlutterError: String {
     case USER_UNAUTHORIZED
     case OTP_ERROR
     case MAGIC_LINK_ERROR
+    case SOCIAL_AUTH_ERROR
     case TOKEN_ERROR
     case APP_INFO_ERROR
     case CHANGE_EMAIL_ERROR

--- a/ios/Classes/PassageFlutterPlugin.swift
+++ b/ios/Classes/PassageFlutterPlugin.swift
@@ -49,6 +49,8 @@ public class PassageFlutterPlugin: NSObject, FlutterPlugin {
             passageFlutter.magicLinkActivate(arguments: call.arguments, result: result)
         case "getMagicLinkStatus":
             passageFlutter.getMagicLinkStatus(arguments: call.arguments, result: result)
+        case "authorizeWith":
+            passageFlutter.authorizeWith(arguments: call.arguments, result: result)
         case "getAuthToken":
             passageFlutter.getAuthToken(result: result)
         case "isAuthTokenValid":

--- a/ios/passage_flutter.podspec
+++ b/ios/passage_flutter.podspec
@@ -15,7 +15,7 @@ A new Flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Passage', '1.4.0'
+  s.dependency 'Passage', '1.5.1'
   s.platform = :ios, '14.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/passage_flutter.dart
+++ b/lib/passage_flutter.dart
@@ -200,6 +200,10 @@ class PassageFlutter {
     return PassageFlutterPlatform.instance.finishSocialAuthentication(code);
   }
 
+  Future<AuthResult> authorizeIOSWith(PassageSocialConnection connection) {
+    return PassageFlutterPlatform.instance.authorizeIOSWith(connection);
+  }
+
   // TOKEN METHODS
 
   /// Returns the auth token for the currently authenticated user.

--- a/lib/passage_flutter.dart
+++ b/lib/passage_flutter.dart
@@ -1,5 +1,6 @@
 import 'passage_flutter_models/auth_result.dart';
 import 'passage_flutter_models/passage_app_info.dart';
+import 'passage_flutter_models/passage_social_connection.dart';
 import 'passage_flutter_models/passage_user.dart';
 import 'passage_flutter_models/passkey.dart';
 import 'passage_flutter_platform/passage_flutter_platform_interface.dart';
@@ -188,6 +189,15 @@ class PassageFlutter {
   ///  `PassageError`
   Future<AuthResult?> getMagicLinkStatus(String magicLinkId) {
     return PassageFlutterPlatform.instance.getMagicLinkStatus(magicLinkId);
+  }
+
+  // SOCIAL AUTH METHODS
+  Future<void> authorizeWith(PassageSocialConnection connection) {
+    return PassageFlutterPlatform.instance.authorizeWith(connection);
+  }
+
+  Future<AuthResult> finishSocialAuthentication(String code) {
+    return PassageFlutterPlatform.instance.finishSocialAuthentication(code);
   }
 
   // TOKEN METHODS

--- a/lib/passage_flutter_models/passage_error_code.dart
+++ b/lib/passage_flutter_models/passage_error_code.dart
@@ -6,6 +6,7 @@ class PassageErrorCode {
   static const userUnauthorized = 'USER_UNAUTHORIZED';
   static const otpError = 'OTP_ERROR';
   static const magicLinkError = 'MAGIC_LINK_ERROR';
+  static const socialAuthError = 'SOCIAL_AUTH_ERROR';
   static const tokenError = 'TOKEN_ERROR';
   static const appInfoError = 'APP_INFO_ERROR';
   static const changeEmailError = 'CHANGE_EMAIL_ERROR';

--- a/lib/passage_flutter_models/passage_social_connection.dart
+++ b/lib/passage_flutter_models/passage_social_connection.dart
@@ -1,0 +1,20 @@
+enum PassageSocialConnection {
+  apple,
+  github,
+  google,
+}
+
+extension PassageSocialConnectionExtension on PassageSocialConnection {
+  String get value {
+    switch (this) {
+      case PassageSocialConnection.apple:
+        return 'apple';
+      case PassageSocialConnection.github:
+        return 'github';
+      case PassageSocialConnection.google:
+        return 'google';
+      default:
+        throw Exception('Unknown PassageSocialConnection value');
+    }
+  }
+}

--- a/lib/passage_flutter_platform/passage_flutter_method_channel.dart
+++ b/lib/passage_flutter_platform/passage_flutter_method_channel.dart
@@ -1,5 +1,7 @@
+import 'dart:io' show Platform;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:passage_flutter/passage_flutter_models/passage_error_code.dart';
 
 import '../passage_flutter_models/passage_social_connection.dart';
 import '/passage_flutter_models/auth_result.dart';
@@ -135,18 +137,50 @@ class MethodChannelPassageFlutter extends PassageFlutterPlatform {
 
   @override
   Future<void> authorizeWith(PassageSocialConnection connection) async {
-    try {} catch (e) {}
+    if (Platform.isIOS) {
+      throw PassageError(
+          code: PassageErrorCode.socialAuthError,
+          message: 'Not supported on iOS. Use authorizeIOSWith instead.');
+    }
+    try {
+      return await methodChannel.invokeMethod<void>(
+          'authorizeWith', {'connection': connection.value});
+    } catch (e) {
+      throw PassageError.fromObject(object: e);
+    }
   }
 
   @override
   Future<AuthResult> finishSocialAuthentication(String code) async {
-    try {} catch (e) {}
+    if (Platform.isIOS) {
+      throw PassageError(
+          code: PassageErrorCode.socialAuthError,
+          message: 'Not supported on iOS. Use authorizeIOSWith instead.');
+    }
+    try {
+      final jsonString = await methodChannel
+          .invokeMethod<String>('finishSocialAuthentication', {'code': code});
+      return AuthResult.fromJson(jsonString!);
+    } catch (e) {
+      throw PassageError.fromObject(object: e);
+    }
   }
 
   @override
   Future<AuthResult> authorizeIOSWith(
       PassageSocialConnection connection) async {
-    try {} catch (e) {}
+    if (!Platform.isIOS) {
+      throw PassageError(
+          code: PassageErrorCode.socialAuthError,
+          message: 'Only supported on iOS. Use authorizeWith instead.');
+    }
+    try {
+      final jsonString = await methodChannel.invokeMethod<String>(
+          'authorizeWith', {'connection': connection.value});
+      return AuthResult.fromJson(jsonString!);
+    } catch (e) {
+      throw PassageError.fromObject(object: e);
+    }
   }
 
   // TOKEN METHODS

--- a/lib/passage_flutter_platform/passage_flutter_method_channel.dart
+++ b/lib/passage_flutter_platform/passage_flutter_method_channel.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
+import '../passage_flutter_models/passage_social_connection.dart';
 import '/passage_flutter_models/auth_result.dart';
 import '/passage_flutter_models/passage_app_info.dart';
 import '/passage_flutter_models/passage_error.dart';
@@ -128,6 +129,24 @@ class MethodChannelPassageFlutter extends PassageFlutterPlatform {
     } catch (e) {
       throw PassageError.fromObject(object: e);
     }
+  }
+
+  // SOCIAL AUTH METHODS
+
+  @override
+  Future<void> authorizeWith(PassageSocialConnection connection) async {
+    try {} catch (e) {}
+  }
+
+  @override
+  Future<AuthResult> finishSocialAuthentication(String code) async {
+    try {} catch (e) {}
+  }
+
+  @override
+  Future<AuthResult> authorizeIOSWith(
+      PassageSocialConnection connection) async {
+    try {} catch (e) {}
   }
 
   // TOKEN METHODS

--- a/lib/passage_flutter_platform/passage_flutter_platform_interface.dart
+++ b/lib/passage_flutter_platform/passage_flutter_platform_interface.dart
@@ -98,6 +98,10 @@ abstract class PassageFlutterPlatform extends PlatformInterface {
         'finishSocialAuthentication() has not been implemented.');
   }
 
+  Future<AuthResult> authorizeIOSWith(PassageSocialConnection connection) {
+    throw UnimplementedError('authorizeIOSWith() has not been implemented.');
+  }
+
   // TOKEN METHODS
 
   Future<String?> getAuthToken() {

--- a/lib/passage_flutter_platform/passage_flutter_platform_interface.dart
+++ b/lib/passage_flutter_platform/passage_flutter_platform_interface.dart
@@ -3,6 +3,7 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import '/passage_flutter_models/auth_result.dart';
 import '/passage_flutter_models/passage_app_info.dart';
 import '/passage_flutter_models/passage_user.dart';
+import '/passage_flutter_models/passage_social_connection.dart';
 import '/passage_flutter_models/passkey.dart';
 import 'passage_flutter_method_channel.dart';
 
@@ -84,6 +85,17 @@ abstract class PassageFlutterPlatform extends PlatformInterface {
 
   Future<AuthResult?> getMagicLinkStatus(String magicLinkId) {
     throw UnimplementedError('getMagicLinkStatus() has not been implemented.');
+  }
+
+  // SOCIAL AUTH METHODS
+
+  Future<void> authorizeWith(PassageSocialConnection connection) {
+    throw UnimplementedError('authorizeWith() has not been implemented.');
+  }
+
+  Future<AuthResult> finishSocialAuthentication(String code) {
+    throw UnimplementedError(
+        'finishSocialAuthentication() has not been implemented.');
   }
 
   // TOKEN METHODS

--- a/lib/passage_flutter_platform/passage_js.dart
+++ b/lib/passage_flutter_platform/passage_js.dart
@@ -23,6 +23,10 @@ class Passage {
   external dynamic magicLinkActivate(String magicLink);
   external dynamic getMagicLinkStatus(String magicLinkId);
 
+  // SOCIAL AUTH METHODS
+  external dynamic authorizeWith(String connection);
+  external dynamic finishSocialAuthentication(String code);
+
   // TOKEN METHODS
   external Session getCurrentSession();
 

--- a/lib/passage_flutter_web.dart
+++ b/lib/passage_flutter_web.dart
@@ -16,6 +16,7 @@ import '/passage_flutter_models/passage_error.dart';
 import './passage_flutter_models/passage_error_code.dart';
 import '/passage_flutter_models/passage_user.dart';
 import '/passage_flutter_models/passkey.dart';
+import 'passage_flutter_models/passage_social_connection.dart';
 import 'passage_flutter_platform/passage_flutter_platform_interface.dart';
 import 'passage_flutter_platform/passage_js.dart';
 
@@ -178,6 +179,31 @@ class PassageFlutterWeb extends PassageFlutterPlatform {
     } catch (e) {
       throw PassageError.fromObject(
           object: e, overrideCode: PassageErrorCode.magicLinkError);
+    }
+  }
+
+  // SOCIAL AUTH METHODS
+  @override
+  Future<void> authorizeWith(PassageSocialConnection connection) async {
+    try {
+      final resultPromise = passage.authorizeWith(connection.value);
+      await js_util.promiseToFuture(resultPromise);
+      return;
+    } catch (e) {
+      throw PassageError.fromObject(
+          object: e, overrideCode: PassageErrorCode.socialAuthError);
+    }
+  }
+
+  @override
+  Future<AuthResult> finishSocialAuthentication(String code) async {
+    try {
+      final resultPromise = passage.finishSocialAuthentication(code);
+      final jsObject = await js_util.promiseToFuture(resultPromise);
+      return AuthResult.fromJson(jsObject);
+    } catch (e) {
+      throw PassageError.fromObject(
+          object: e, overrideCode: PassageErrorCode.socialAuthError);
     }
   }
 

--- a/lib/passage_flutter_web.dart
+++ b/lib/passage_flutter_web.dart
@@ -183,6 +183,7 @@ class PassageFlutterWeb extends PassageFlutterPlatform {
   }
 
   // SOCIAL AUTH METHODS
+
   @override
   Future<void> authorizeWith(PassageSocialConnection connection) async {
     try {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: passage_flutter
 description: Native passkey authentication for your Flutter app
-version: 0.5.0
+version: 0.6.0
 homepage: https://github.com/passageidentity/passage-flutter
 
 environment:


### PR DESCRIPTION
## What's new

Users can now log in to a Passage app using Social Login.
Upon successful login using passage.authorizeWith, Passage Flutter will save the user's tokens to device.

## Example code
```dart
const connection = PassageSocialConnection.github

// Web and Android
// Step 1: Send user to Social Login page
passage.authorizeWith(connection);
// Step 2: When Social Login page redirects to your app, extract the auth code to finish login
final uri = Uri.parse(YOUR_REDIRECT_URI);
final code = uri.queryParameters['code'];
final authResult = await passage.finishSocialAuthentication(code);

// iOS
// iOS handles the process in a single step.
final authResult = await passage.authorizeIOSWith(connection);
```

