### PR TITLE
Updated passkey auth methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## 0.7.0
+
+### What's new
+
+* Added new and improved `registerWithPasskey` and `loginWithPasskey` methods.
+* Deprecated `login` and `register` methods.
+
+### Example code
+```dart
+final identifier = 'name@email.com'
+
+// Register a new user with a passkey and optionally provide `PasskeyCreationOptions`.
+// These example options will allow a user to register using a physical security key.
+final options = PasskeyCreationOptions(
+  authenticatorAttachment: AuthenticatorAttachment.crossPlatform);
+await _passage.registerWithPasskey(identifier, options);
+
+// Log in using a passkey and optionally pass a user identifier.
+await _passage.loginWithPasskey(identifier);
+```
+
 ## 0.6.1
 
 Update Passage Android dependency.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,7 +48,7 @@ android {
     dependencies {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
-        implementation 'id.passage.android:passage:1.6.1'
+        implementation 'id.passage.android:passage:1.7.0'
         implementation 'com.google.code.gson:gson:2.9.0'
     }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,7 +48,7 @@ android {
     dependencies {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
-        implementation 'id.passage.android:passage:1.7.0'
+        implementation 'id.passage.android:passage:1.7.1'
         implementation 'com.google.code.gson:gson:2.9.0'
     }
 

--- a/android/src/main/kotlin/id/passage/passage_flutter/PassageFlutter.kt
+++ b/android/src/main/kotlin/id/passage/passage_flutter/PassageFlutter.kt
@@ -34,7 +34,7 @@ internal class PassageFlutter(private val activity: Activity, appId: String? = n
 
     // region PASSKEY METHODS
 
-    internal fun register(call: MethodCall, result: MethodChannel.Result) {
+    internal fun registerWithPasskey(call: MethodCall, result: MethodChannel.Result) {
         val identifier = call.argument<String>("identifier")
             ?: return invalidArgumentError(result)
         CoroutineScope(Dispatchers.IO).launch {
@@ -54,10 +54,11 @@ internal class PassageFlutter(private val activity: Activity, appId: String? = n
         }
     }
 
-    internal fun login(result: MethodChannel.Result) {
+    internal fun loginWithPasskey(call: MethodCall, result: MethodChannel.Result) {
+        val identifier = call.argument<String>("identifier")
         CoroutineScope(Dispatchers.IO).launch {
             try {
-                val authResult = passage.loginWithPasskey("")
+                val authResult = passage.loginWithPasskey(identifier)
                 val jsonString = Gson().toJson(authResult)
                 result.success(jsonString)
             } catch (e: Exception) {

--- a/android/src/main/kotlin/id/passage/passage_flutter/PassageFlutterPlugin.kt
+++ b/android/src/main/kotlin/id/passage/passage_flutter/PassageFlutterPlugin.kt
@@ -63,7 +63,7 @@ class PassageFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
           "identifierExists" -> passageFlutter?.identifierExists(call, result)
           "getCurrentUser" -> passageFlutter?.getCurrentUser(result)
           "signOut" -> passageFlutter?.signOut(result)
-          "addPasskey" -> passageFlutter?.addPasskey(result)
+          "addPasskey" -> passageFlutter?.addPasskey(call, result)
           "deletePasskey" -> passageFlutter?.deletePasskey(call, result)
           "editPasskeyName" -> passageFlutter?.editPasskeyName(call, result)
           "changeEmail" -> passageFlutter?.changeEmail(call, result)

--- a/android/src/main/kotlin/id/passage/passage_flutter/PassageFlutterPlugin.kt
+++ b/android/src/main/kotlin/id/passage/passage_flutter/PassageFlutterPlugin.kt
@@ -44,8 +44,8 @@ class PassageFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
 
       when (call.method) {
           "initWithAppId" -> {}
-          "register" -> passageFlutter?.register(call, result)
-          "login" -> passageFlutter?.login(result)
+          "registerWithPasskey" -> passageFlutter?.registerWithPasskey(call, result)
+          "loginWithPasskey" -> passageFlutter?.loginWithPasskey(call, result)
           "deviceSupportsPasskeys" -> passageFlutter?.deviceSupportsPasskeys(result)
           "newRegisterOneTimePasscode" -> passageFlutter?.newRegisterOneTimePasscode(call, result)
           "newLoginOneTimePasscode" -> passageFlutter?.newLoginOneTimePasscode(call, result)

--- a/ios/Classes/PassageFlutter.swift
+++ b/ios/Classes/PassageFlutter.swift
@@ -27,7 +27,8 @@ internal class PassageFlutter {
         Task {
             do {
                 var passkeyCreationOptions: PasskeyCreationOptions? = nil
-                if let authenticatorAttachmentString = (arguments as? [String: String])?["authenticatorAttachment"] as? String,
+                if let optionsDictionary = (arguments as? [String: Any])?["options"] as? [String: String],
+                   let authenticatorAttachmentString = optionsDictionary["authenticatorAttachment"],
                    let authenticatorAttachment = AuthenticatorAttachment(rawValue: authenticatorAttachmentString)
                 {
                     passkeyCreationOptions = PasskeyCreationOptions(authenticatorAttachment: authenticatorAttachment)
@@ -358,7 +359,8 @@ internal class PassageFlutter {
         Task {
             do {
                 var passkeyCreationOptions: PasskeyCreationOptions? = nil
-                if let authenticatorAttachmentString = (arguments as? [String: String])?["authenticatorAttachment"] as? String,
+                if let optionsDictionary = (arguments as? [String: Any])?["options"] as? [String: String],
+                   let authenticatorAttachmentString = optionsDictionary["authenticatorAttachment"],
                    let authenticatorAttachment = AuthenticatorAttachment(rawValue: authenticatorAttachmentString)
                 {
                     passkeyCreationOptions = PasskeyCreationOptions(authenticatorAttachment: authenticatorAttachment)
@@ -504,7 +506,7 @@ internal class PassageFlutter {
 extension PassageFlutter {
     
     private func getIdentifier(from arguments: Any?) -> (String?, FlutterError?) {
-        guard let identifier = (arguments as? [String: String])?["identifier"] else {
+        guard let identifier = (arguments as? [String: Any])?["identifier"] as? String else {
             let error = PassageFlutterError.INVALID_ARGUMENT.defaultFlutterError
             return (nil, error)
         }

--- a/ios/Classes/PassageFlutter.swift
+++ b/ios/Classes/PassageFlutter.swift
@@ -13,7 +13,7 @@ internal class PassageFlutter {
         passage = PassageAuth(appId: appId)
     }
     
-    internal func register(arguments: Any?, result: @escaping FlutterResult) {
+    internal func registerWithPasskey(arguments: Any?, result: @escaping FlutterResult) {
         guard #available(iOS 16.0, *) else {
             let error = PassageFlutterError.PASSKEYS_NOT_SUPPORTED.defaultFlutterError
             result(error)
@@ -42,15 +42,16 @@ internal class PassageFlutter {
         }
     }
     
-    internal func login(result: @escaping FlutterResult) {
+    internal func loginWithPasskey(arguments: Any?, result: @escaping FlutterResult) {
         guard #available(iOS 16.0, *) else {
             let error = PassageFlutterError.PASSKEYS_NOT_SUPPORTED.defaultFlutterError
             result(error)
             return
         }
+        let (identifier, _) = getIdentifier(from: arguments)
         Task {
             do {
-                let authResult = try await passage.loginWithPasskey()
+                let authResult = try await passage.loginWithPasskey(identifier: identifier)
                 result(convertToJsonString(codable: authResult))
             } catch PassageASAuthorizationError.canceled {
                 let error = PassageFlutterError.USER_CANCELLED.defaultFlutterError

--- a/ios/Classes/PassageFlutter.swift
+++ b/ios/Classes/PassageFlutter.swift
@@ -26,7 +26,13 @@ internal class PassageFlutter {
         }
         Task {
             do {
-                let authResult = try await passage.registerWithPasskey(identifier: identifier)
+                var passkeyCreationOptions: PasskeyCreationOptions? = nil
+                if let authenticatorAttachmentString = (arguments as? [String: String])?["authenticatorAttachment"] as? String,
+                   let authenticatorAttachment = AuthenticatorAttachment(rawValue: authenticatorAttachmentString)
+                {
+                    passkeyCreationOptions = PasskeyCreationOptions(authenticatorAttachment: authenticatorAttachment)
+                }
+                let authResult = try await passage.registerWithPasskey(identifier: identifier, options: passkeyCreationOptions)
                 result(convertToJsonString(codable: authResult))
             } catch PassageASAuthorizationError.canceled {
                 let error = PassageFlutterError.USER_CANCELLED.defaultFlutterError
@@ -351,7 +357,13 @@ internal class PassageFlutter {
         }
         Task {
             do {
-                let device = try await passage.addDevice()
+                var passkeyCreationOptions: PasskeyCreationOptions? = nil
+                if let authenticatorAttachmentString = (arguments as? [String: String])?["authenticatorAttachment"] as? String,
+                   let authenticatorAttachment = AuthenticatorAttachment(rawValue: authenticatorAttachmentString)
+                {
+                    passkeyCreationOptions = PasskeyCreationOptions(authenticatorAttachment: authenticatorAttachment)
+                }
+                let device = try await passage.addDevice(options: passkeyCreationOptions)
                 result(convertToJsonString(codable: device))
             } catch {
                 let error = FlutterError(

--- a/ios/Classes/PassageFlutterPlugin.swift
+++ b/ios/Classes/PassageFlutterPlugin.swift
@@ -29,10 +29,10 @@ public class PassageFlutterPlugin: NSObject, FlutterPlugin {
         
         switch call.method {
         case "initWithAppId": ()
-        case "register":
-            passageFlutter.register(arguments: call.arguments, result: result)
-        case "login":
-            passageFlutter.login(result: result)
+        case "registerWithPasskey":
+            passageFlutter.registerWithPasskey(arguments: call.arguments, result: result)
+        case "loginWithPasskey":
+            passageFlutter.loginWithPasskey(arguments: call.arguments, result: result)
         case "deviceSupportsPasskeys":
             passageFlutter.deviceSupportsPasskeys(result: result)
         case "newRegisterOneTimePasscode":

--- a/ios/passage_flutter.podspec
+++ b/ios/passage_flutter.podspec
@@ -1,17 +1,13 @@
-#
-# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
-# Run `pod lib lint passage_flutter.podspec` to validate before publishing.
-#
 Pod::Spec.new do |s|
   s.name             = 'passage_flutter'
-  s.version          = '0.6.1'
-  s.summary          = 'A new Flutter plugin project.'
+  s.version          = '0.7.0'
+  s.summary          = 'Passkey authentication for your Flutter app'
   s.description      = <<-DESC
-A new Flutter plugin project.
+  Passkey authentication for your Flutter app
                        DESC
-  s.homepage         = 'http://example.com'
+  s.homepage         = 'http://passage.id'
   s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Your Company' => 'email@example.com' }
+  s.author           = { 'Passage' => 'hello@passage.id' }
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'

--- a/ios/passage_flutter.podspec
+++ b/ios/passage_flutter.podspec
@@ -15,7 +15,7 @@ A new Flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Passage', '1.5.1'
+  s.dependency 'Passage', '1.6.0'
   s.platform = :ios, '14.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/passage_flutter.dart
+++ b/lib/passage_flutter.dart
@@ -62,7 +62,7 @@ class PassageFlutter {
   ///  - User does not exist
   ///  - App configuration was not done properly
   ///  - etc.
-  Future<AuthResult> loginWithPasskey(String? identifier) {
+  Future<AuthResult> loginWithPasskey([String? identifier]) {
     return PassageFlutterPlatform.instance.loginWithPasskey(identifier);
   }
 

--- a/lib/passage_flutter.dart
+++ b/lib/passage_flutter.dart
@@ -1,4 +1,5 @@
 import 'passage_flutter_models/auth_result.dart';
+import 'passage_flutter_models/authenticator_attachment.dart';
 import 'passage_flutter_models/passage_app_info.dart';
 import 'passage_flutter_models/passage_social_connection.dart';
 import 'passage_flutter_models/passage_user.dart';
@@ -21,6 +22,7 @@ class PassageFlutter {
   ///
   /// Parameters:
   ///  - `identifier`: Email address or phone for the user.
+  ///  - `options`: Optional configuration for passkey creation.
   ///
   /// Returns:
   ///  A `Future<AuthResult>` object that includes a redirect URL and saves the
@@ -32,14 +34,17 @@ class PassageFlutter {
   ///  - User already exists
   ///  - App configuration was not done properly
   ///  - etc.
-  Future<AuthResult> registerWithPasskey(String identifier) {
-    return PassageFlutterPlatform.instance.registerWithPasskey(identifier);
+  Future<AuthResult> registerWithPasskey(String identifier,
+      [PasskeyCreationOptions? options]) {
+    return PassageFlutterPlatform.instance
+        .registerWithPasskey(identifier, options);
   }
 
   /// **DEPRECATED. Use `registerWithPasskey` instead.**
   @Deprecated('Use `registerWithPasskey` instead.')
   Future<AuthResult> register(String identifier) {
-    return PassageFlutterPlatform.instance.registerWithPasskey(identifier);
+    return PassageFlutterPlatform.instance
+        .registerWithPasskey(identifier, null);
   }
 
   /// Attempts to login a user with a passkey.
@@ -271,6 +276,9 @@ class PassageFlutter {
 
   /// Attempts to create and register a new passkey for the authenticated user.
   ///
+  /// Parameters:
+  ///  - `options`: Optional configuration for passkey creation.
+  ///
   /// Returns:
   ///  A `Future<Passkey>` representing an object containing all of the data about the new passkey.
   ///
@@ -279,8 +287,8 @@ class PassageFlutter {
   ///  - User cancels the operation
   ///  - App configuration was not done properly
   ///  - etc.
-  Future<Passkey> addPasskey() {
-    return PassageFlutterPlatform.instance.addPasskey();
+  Future<Passkey> addPasskey([PasskeyCreationOptions? options]) {
+    return PassageFlutterPlatform.instance.addPasskey(options);
   }
 
   /// Removes a passkey from a user's account.

--- a/lib/passage_flutter.dart
+++ b/lib/passage_flutter.dart
@@ -32,13 +32,20 @@ class PassageFlutter {
   ///  - User already exists
   ///  - App configuration was not done properly
   ///  - etc.
+  Future<AuthResult> registerWithPasskey(String identifier) {
+    return PassageFlutterPlatform.instance.registerWithPasskey(identifier);
+  }
+
+  /// **DEPRECATED. Use `registerWithPasskey` instead.**
+  @Deprecated('Use `registerWithPasskey` instead.')
   Future<AuthResult> register(String identifier) {
-    return PassageFlutterPlatform.instance.register(identifier);
+    return PassageFlutterPlatform.instance.registerWithPasskey(identifier);
   }
 
   /// Attempts to login a user with a passkey.
   ///
-  /// **NOTE:** Web apps should use `loginWithIdentifier` instead.
+  /// Parameters:
+  ///  - `identifier`: Email address or phone for the user (optional).
   ///
   /// Returns:
   ///  A `Future<AuthResult>` object that includes a redirect URL and saves the
@@ -50,26 +57,20 @@ class PassageFlutter {
   ///  - User does not exist
   ///  - App configuration was not done properly
   ///  - etc.
+  Future<AuthResult> loginWithPasskey(String? identifier) {
+    return PassageFlutterPlatform.instance.loginWithPasskey(identifier);
+  }
+
+  /// **DEPRECATED. Use `loginWithPasskey` instead.**
+  @Deprecated('Use `loginWithPasskey` instead.')
   Future<AuthResult> login() {
-    return PassageFlutterPlatform.instance.login();
+    return PassageFlutterPlatform.instance.loginWithPasskey('');
   }
 
-  /// Attempts to login a user with a passkey.
-  ///
-  /// **NOTE:** Mobile apps should use `login` instead.
-  ///
-  /// Returns:
-  ///  A `Future<AuthResult>` object that includes a redirect URL and saves the
-  ///  authorization token and (optional) refresh token securely to the device.
-  ///
-  /// Throws:
-  ///  A `PassageError` in cases such as:
-  ///  - User cancels the operation
-  ///  - User does not exist
-  ///  - App configuration was not done properly
-  ///  - etc.
+  /// **DEPRECATED. Use `loginWithPasskey` instead.**
+  @Deprecated('Use `loginWithPasskey` instead.')
   Future<AuthResult> loginWithIdentifier(String identifier) {
-    return PassageFlutterPlatform.instance.loginWithIdentifier(identifier);
+    return PassageFlutterPlatform.instance.loginWithPasskey(identifier);
   }
 
   Future<bool> deviceSupportsPasskeys() {

--- a/lib/passage_flutter_models/authenticator_attachment.dart
+++ b/lib/passage_flutter_models/authenticator_attachment.dart
@@ -1,0 +1,32 @@
+enum AuthenticatorAttachment {
+  platform,
+  crossPlatform,
+  any,
+}
+
+// Extension on AuthenticatorAttachment to get string values
+extension AuthenticatorAttachmentExtension on AuthenticatorAttachment {
+  String get value {
+    switch (this) {
+      case AuthenticatorAttachment.platform:
+        return 'platform';
+      case AuthenticatorAttachment.crossPlatform:
+        return 'cross-platform';
+      case AuthenticatorAttachment.any:
+        return 'any';
+      default:
+        return '';
+    }
+  }
+}
+
+// Class definition for PasskeyCreationOptions
+class PasskeyCreationOptions {
+  AuthenticatorAttachment? authenticatorAttachment;
+
+  PasskeyCreationOptions({this.authenticatorAttachment});
+
+  Map<String, dynamic> toJson() => {
+        "authenticatorAttachment": authenticatorAttachment?.value,
+      };
+}

--- a/lib/passage_flutter_platform/passage_flutter_method_channel.dart
+++ b/lib/passage_flutter_platform/passage_flutter_method_channel.dart
@@ -25,10 +25,10 @@ class MethodChannelPassageFlutter extends PassageFlutterPlatform {
   // PASSKEY AUTH METHODS
 
   @override
-  Future<AuthResult> register(String identifier) async {
+  Future<AuthResult> registerWithPasskey(String identifier) async {
     try {
-      final jsonString = await methodChannel
-          .invokeMethod<String>('register', {'identifier': identifier});
+      final jsonString = await methodChannel.invokeMethod<String>(
+          'registerWithPasskey', {'identifier': identifier});
       return AuthResult.fromJson(jsonString!);
     } catch (e) {
       throw PassageError.fromObject(object: e);
@@ -36,9 +36,10 @@ class MethodChannelPassageFlutter extends PassageFlutterPlatform {
   }
 
   @override
-  Future<AuthResult> login() async {
+  Future<AuthResult> loginWithPasskey(String? identifier) async {
     try {
-      final jsonString = await methodChannel.invokeMethod<String>('login');
+      final jsonString = await methodChannel
+          .invokeMethod<String>('loginWithPasskey', {'identifier': identifier});
       return AuthResult.fromJson(jsonString!);
     } catch (e) {
       throw PassageError.fromObject(object: e);

--- a/lib/passage_flutter_platform/passage_flutter_method_channel.dart
+++ b/lib/passage_flutter_platform/passage_flutter_method_channel.dart
@@ -5,6 +5,7 @@ import 'package:passage_flutter/passage_flutter_models/passage_error_code.dart';
 
 import '../passage_flutter_models/passage_social_connection.dart';
 import '/passage_flutter_models/auth_result.dart';
+import '/passage_flutter_models/authenticator_attachment.dart';
 import '/passage_flutter_models/passage_app_info.dart';
 import '/passage_flutter_models/passage_error.dart';
 import '/passage_flutter_models/passage_user.dart';
@@ -25,10 +26,12 @@ class MethodChannelPassageFlutter extends PassageFlutterPlatform {
   // PASSKEY AUTH METHODS
 
   @override
-  Future<AuthResult> registerWithPasskey(String identifier) async {
+  Future<AuthResult> registerWithPasskey(
+      String identifier, PasskeyCreationOptions? options) async {
     try {
       final jsonString = await methodChannel.invokeMethod<String>(
-          'registerWithPasskey', {'identifier': identifier});
+          'registerWithPasskey',
+          {'identifier': identifier, options: options?.toJson()});
       return AuthResult.fromJson(jsonString!);
     } catch (e) {
       throw PassageError.fromObject(object: e);
@@ -265,9 +268,10 @@ class MethodChannelPassageFlutter extends PassageFlutterPlatform {
   }
 
   @override
-  Future<Passkey> addPasskey() async {
+  Future<Passkey> addPasskey(PasskeyCreationOptions? options) async {
     try {
-      final jsonString = await methodChannel.invokeMethod<String>('addPasskey');
+      final jsonString = await methodChannel
+          .invokeMethod<String>('addPasskey', {'options': options?.toJson()});
       return Passkey.fromJson(jsonString!);
     } catch (e) {
       throw PassageError.fromObject(object: e);

--- a/lib/passage_flutter_platform/passage_flutter_method_channel.dart
+++ b/lib/passage_flutter_platform/passage_flutter_method_channel.dart
@@ -31,7 +31,7 @@ class MethodChannelPassageFlutter extends PassageFlutterPlatform {
     try {
       final jsonString = await methodChannel.invokeMethod<String>(
           'registerWithPasskey',
-          {'identifier': identifier, options: options?.toJson()});
+          {'identifier': identifier, 'options': options?.toJson()});
       return AuthResult.fromJson(jsonString!);
     } catch (e) {
       throw PassageError.fromObject(object: e);

--- a/lib/passage_flutter_platform/passage_flutter_platform_interface.dart
+++ b/lib/passage_flutter_platform/passage_flutter_platform_interface.dart
@@ -34,16 +34,12 @@ abstract class PassageFlutterPlatform extends PlatformInterface {
 
   // PASSKEY AUTH METHODS
 
-  Future<AuthResult> register(String identifier) {
-    throw UnimplementedError('register() has not been implemented.');
+  Future<AuthResult> registerWithPasskey(String identifier) {
+    throw UnimplementedError('registerWithPasskey() has not been implemented.');
   }
 
-  Future<AuthResult> login() {
-    throw UnimplementedError('login() only supported on Android and iOS.');
-  }
-
-  Future<AuthResult> loginWithIdentifier(String identifier) {
-    throw UnimplementedError('loginWithIdentifier() only supported on web.');
+  Future<AuthResult> loginWithPasskey(String? identifier) {
+    throw UnimplementedError('loginWithPasskey() as not been implemented.');
   }
 
   Future<bool> deviceSupportsPasskeys() {

--- a/lib/passage_flutter_platform/passage_flutter_platform_interface.dart
+++ b/lib/passage_flutter_platform/passage_flutter_platform_interface.dart
@@ -1,6 +1,7 @@
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import '/passage_flutter_models/auth_result.dart';
+import '/passage_flutter_models/authenticator_attachment.dart';
 import '/passage_flutter_models/passage_app_info.dart';
 import '/passage_flutter_models/passage_user.dart';
 import '/passage_flutter_models/passage_social_connection.dart';
@@ -34,7 +35,8 @@ abstract class PassageFlutterPlatform extends PlatformInterface {
 
   // PASSKEY AUTH METHODS
 
-  Future<AuthResult> registerWithPasskey(String identifier) {
+  Future<AuthResult> registerWithPasskey(
+      String identifier, PasskeyCreationOptions? options) {
     throw UnimplementedError('registerWithPasskey() has not been implemented.');
   }
 
@@ -132,7 +134,7 @@ abstract class PassageFlutterPlatform extends PlatformInterface {
     throw UnimplementedError('getCurrentUser() has not been implemented.');
   }
 
-  Future<Passkey> addPasskey() {
+  Future<Passkey> addPasskey(PasskeyCreationOptions? options) {
     throw UnimplementedError('addPasskey() has not been implemented.');
   }
 

--- a/lib/passage_flutter_platform/passage_js.dart
+++ b/lib/passage_flutter_platform/passage_js.dart
@@ -8,7 +8,7 @@ class Passage {
   external factory Passage(String appId);
 
   // PASSKEY AUTH METHODS
-  external dynamic register(String identifier);
+  external dynamic register(String identifier, dynamic options);
   external dynamic login(String identifier);
   external IGetCredentialFeatures getCredentialAvailable();
 
@@ -41,7 +41,7 @@ class Passage {
 @JS()
 class User {
   external dynamic userInfo();
-  external dynamic addDevice();
+  external dynamic addDevice(dynamic options);
   external dynamic deleteDevice(String passkeyId);
   external dynamic editDevice(String passkeyId, dynamic obj);
   external dynamic changeEmail(String newEmail);

--- a/lib/passage_flutter_web.dart
+++ b/lib/passage_flutter_web.dart
@@ -54,7 +54,8 @@ class PassageFlutterWeb extends PassageFlutterPlatform {
       throw PassageError(code: PassageErrorCode.passkeysNotSupported);
     }
     try {
-      final resultPromise = passage.register(identifier, options?.toJson());
+      final jsOptions = js_util.jsify(options?.toJson());
+      final resultPromise = passage.register(identifier, jsOptions);
       final jsObject = await js_util.promiseToFuture(resultPromise);
       return AuthResult.fromJson(jsObject);
     } catch (e) {
@@ -323,8 +324,8 @@ class PassageFlutterWeb extends PassageFlutterPlatform {
       throw PassageError(code: PassageErrorCode.passkeysNotSupported);
     }
     try {
-      final resultPromise =
-          passage.getCurrentUser().addDevice(options?.toJson());
+      final jsOptions = js_util.jsify(options?.toJson());
+      final resultPromise = passage.getCurrentUser().addDevice(jsOptions);
       final jsObject = await js_util.promiseToFuture(resultPromise);
       return Passkey.fromJson(jsObject);
     } catch (e) {

--- a/lib/passage_flutter_web.dart
+++ b/lib/passage_flutter_web.dart
@@ -11,6 +11,7 @@ import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
 import '/helpers/data_conversion_web.dart';
 import '/passage_flutter_models/auth_result.dart';
+import '/passage_flutter_models/authenticator_attachment.dart';
 import '/passage_flutter_models/passage_app_info.dart';
 import '/passage_flutter_models/passage_error.dart';
 import './passage_flutter_models/passage_error_code.dart';
@@ -46,13 +47,14 @@ class PassageFlutterWeb extends PassageFlutterPlatform {
   // PASSKEY AUTH METHODS
 
   @override
-  Future<AuthResult> registerWithPasskey(String identifier) async {
+  Future<AuthResult> registerWithPasskey(
+      String identifier, PasskeyCreationOptions? options) async {
     final passkeysSupported = await deviceSupportsPasskeys();
     if (!passkeysSupported) {
       throw PassageError(code: PassageErrorCode.passkeysNotSupported);
     }
     try {
-      final resultPromise = passage.register(identifier);
+      final resultPromise = passage.register(identifier, options?.toJson());
       final jsObject = await js_util.promiseToFuture(resultPromise);
       return AuthResult.fromJson(jsObject);
     } catch (e) {
@@ -315,13 +317,14 @@ class PassageFlutterWeb extends PassageFlutterPlatform {
   }
 
   @override
-  Future<Passkey> addPasskey() async {
+  Future<Passkey> addPasskey(PasskeyCreationOptions? options) async {
     final passkeysSupported = await deviceSupportsPasskeys();
     if (!passkeysSupported) {
       throw PassageError(code: PassageErrorCode.passkeysNotSupported);
     }
     try {
-      final resultPromise = passage.getCurrentUser().addDevice();
+      final resultPromise =
+          passage.getCurrentUser().addDevice(options?.toJson());
       final jsObject = await js_util.promiseToFuture(resultPromise);
       return Passkey.fromJson(jsObject);
     } catch (e) {

--- a/lib/passage_flutter_web.dart
+++ b/lib/passage_flutter_web.dart
@@ -46,7 +46,7 @@ class PassageFlutterWeb extends PassageFlutterPlatform {
   // PASSKEY AUTH METHODS
 
   @override
-  Future<AuthResult> register(String identifier) async {
+  Future<AuthResult> registerWithPasskey(String identifier) async {
     final passkeysSupported = await deviceSupportsPasskeys();
     if (!passkeysSupported) {
       throw PassageError(code: PassageErrorCode.passkeysNotSupported);
@@ -62,13 +62,13 @@ class PassageFlutterWeb extends PassageFlutterPlatform {
   }
 
   @override
-  Future<AuthResult> loginWithIdentifier(String identifier) async {
+  Future<AuthResult> loginWithPasskey(String? identifier) async {
     final passkeysSupported = await deviceSupportsPasskeys();
     if (!passkeysSupported) {
       throw PassageError(code: PassageErrorCode.passkeysNotSupported);
     }
     try {
-      final resultPromise = passage.login(identifier);
+      final resultPromise = passage.login(identifier ?? '');
       final jsObject = await js_util.promiseToFuture(resultPromise);
       return AuthResult.fromJson(jsObject);
     } catch (e) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: passage_flutter
 description: Native passkey authentication for your Flutter app
-version: 0.6.1
+version: 0.7.0
 homepage: https://github.com/passageidentity/passage-flutter
 
 environment:


### PR DESCRIPTION
# What's new

### New passkey auth methods
* Added new and improved `registerWithPasskey` and `loginWithPasskey` methods.
* Deprecated `login` and `register` methods.

### Authenticator Attachments
Developers can now set `PasskeyCreationOptions` when calling passage.registerWithPasskey.
This new object contains one property called authenticatorAttachments which provides developers with more granular control of their users' passkey creation experience.
You can learn more about authenticator attachments in the [WebAuthn spec](https://w3c.github.io/webauthn/#dictionary-authenticatorSelection).

# Example code
```dart
final identifier = 'name@email.com'

// Register a new user with a passkey and optionally provide `PasskeyCreationOptions`.
// These example options will allow a user to register using a physical security key.
final options = PasskeyCreationOptions(
  authenticatorAttachment: AuthenticatorAttachment.crossPlatform);
await _passage.registerWithPasskey(identifier, options);

// Log in using a passkey and optionally pass a user identifier.
await _passage.loginWithPasskey(identifier);
```

# User experience
Example UI for "cross-platform" or "any" authenticator attachment option.
<img src="https://github.com/passageidentity/passage-ios/assets/16176400/25a9598a-6641-4911-8bcc-3b5284f3f95d" width="550"/>
