### PR TITLE
fix(PSG-3402): kotlin enums were getting improperly obfuscated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.1
+
+Fixed issue with Android code obfuscation.
+
 ## 0.7.0
 
 ### What's new

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,7 +48,7 @@ android {
     dependencies {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
-        implementation 'id.passage.android:passage:1.7.1'
+        implementation 'id.passage.android:passage:1.7.3'
         implementation 'com.google.code.gson:gson:2.9.0'
     }
 
@@ -62,10 +62,6 @@ android {
                showStandardStreams = true
             }
         }
-    }
-
-    buildTypes.configureEach { buildType ->
-        buildType.consumerProguardFiles 'proguard-rules.pro'
     }
 
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -63,4 +63,9 @@ android {
             }
         }
     }
+
+    buildTypes.configureEach { buildType ->
+        buildType.consumerProguardFiles 'proguard-rules.pro'
+    }
+
 }

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,0 +1,1 @@
+-keep class id.passage.android.** { *; }

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,1 +1,0 @@
--keep class id.passage.android.** { *; }

--- a/ios/passage_flutter.podspec
+++ b/ios/passage_flutter.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'passage_flutter'
-  s.version          = '0.7.0'
+  s.version          = '0.7.1'
   s.summary          = 'Passkey authentication for your Flutter app'
   s.description      = <<-DESC
   Passkey authentication for your Flutter app

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: passage_flutter
 description: Native passkey authentication for your Flutter app
-version: 0.7.0
+version: 0.7.1
 homepage: https://github.com/passageidentity/passage-flutter
 
 environment:


### PR DESCRIPTION
In some cases, Android "release" build types would improperly obfuscate generated Kotlin enum values that would lead to unexpected results.

This fix prevents this issue by preventing Passage Android code from getting obfuscated.